### PR TITLE
Fix(?) for a destructive resleeve failure case

### DIFF
--- a/1.4/Source/AlteredCarbon/Stacks/PersonaData.cs
+++ b/1.4/Source/AlteredCarbon/Stacks/PersonaData.cs
@@ -971,7 +971,7 @@ namespace AlteredCarbon
                 for (var i = otherPawnRelations.Count - 1; i >= 0; i--)
                 {
                     var rel = otherPawnRelations[i];
-                    if (IsPresetPawn(rel.otherPawn))
+                    if (rel != null && IsPresetPawn(rel.otherPawn))
                     {
                         if (rel.otherPawn != newReference)
                         {
@@ -994,6 +994,7 @@ namespace AlteredCarbon
 
         public bool IsPresetPawn(Pawn pawn)
         {
+            if (pawn == null || pawn.Name == null) return false;
             return pawn != null && (pawn.thingIDNumber == pawnID || origPawn == pawn || name.ToString() == pawn.Name.ToString());
         }
 


### PR DESCRIPTION
Not really sure _what_ went wrong, but I had a pawn I wanted to resleeve, only to get
"System.NullReferenceException: Object reference not set to an instance of an object at AlteredCarbon.PersonaData.IsPresetPawn" etc etc.
Ultimately what solved it for me was adding this check in there for a null name - it still excepts later on in AlteredCarbon.Recipe_InstallCorticalStack.ApplyOnPawn, but at that point the pawn seems to have been mostly set up - as far as I can tell the only 'loss' was the pawn's father ended up erased from her history.

(Since the off-map father does have an appearance in Character Editor, I'd speculate something about how he was recorded into the stack went wrong, but I don't have the familiarity to really figure what the root cause was/is.)