### PR TITLE
Fix a typo concerning newlines

### DIFF
--- a/1.4/LoadFolders/Standalone/Defs/ThingDefs_Buildings/Buildings_Ultratech.xml
+++ b/1.4/LoadFolders/Standalone/Defs/ThingDefs_Buildings/Buildings_Ultratech.xml
@@ -179,7 +179,7 @@
 	<ThingDef ParentName="BenchBase">
 		<defName>VFEU_DecryptionBench</defName>
 		<label>decryption bench</label>
-		<description>A sophisticated workbench that allows the user to connect to cortical stacks in order to alter the contained information, such as changing allegiance, or even wipe them clean. Can also strip the biocoding from items./n/nAs the process is quite aggressive, there is a risk of the decryption process destroying the item.</description>
+		<description>A sophisticated workbench that allows the user to connect to cortical stacks in order to alter the contained information, such as changing allegiance, or even wipe them clean. Can also strip the biocoding from items.\n\nAs the process is quite aggressive, there is a risk of the decryption process destroying the item.</description>
 		<thingClass>AlteredCarbon.Building_DecryptionBench</thingClass>
 		<graphicData>
 			<texPath>Things/Building/Misc/HackingWorkbench/HackingWorkbench</texPath>


### PR DESCRIPTION
Fixes a typo that uses `/n` instead of `\n`.